### PR TITLE
Rework nodes, examples and libraries resolution

### DIFF
--- a/complex.go
+++ b/complex.go
@@ -55,11 +55,11 @@ func (s *ArrayShape) UnmarshalYAMLNodes(v []*yaml.Node) error {
 				return fmt.Errorf("decode uniqueItems: %w", err)
 			}
 		} else {
-			dt, err := MakeNode(valueNode, s.Location)
+			n, err := MakeNode(valueNode, s.Location)
 			if err != nil {
 				return fmt.Errorf("make node: %w", err)
 			}
-			s.CustomShapeFacets[node.Value] = dt
+			s.CustomShapeFacets[node.Value] = n
 		}
 	}
 	return nil
@@ -108,7 +108,7 @@ func (s *ObjectShape) UnmarshalYAMLNodes(v []*yaml.Node) error {
 				return fmt.Errorf("decode maxProperties: %w", err)
 			}
 		} else if node.Value == "properties" {
-			s.Properties = make(map[string]*Property)
+			s.Properties = make(map[string]*Property, len(valueNode.Content)/2)
 			for j := 0; j != len(valueNode.Content); j += 2 {
 				name := valueNode.Content[j].Value
 				data := valueNode.Content[j+1]
@@ -120,11 +120,11 @@ func (s *ObjectShape) UnmarshalYAMLNodes(v []*yaml.Node) error {
 				GetRegistry().PutIntoFragment(s.Name+"#"+property.Name, s.Location, property.Shape)
 			}
 		} else {
-			dt, err := MakeNode(valueNode, s.Location)
+			n, err := MakeNode(valueNode, s.Location)
 			if err != nil {
 				return fmt.Errorf("make node: %w", err)
 			}
-			s.CustomShapeFacets[node.Value] = dt
+			s.CustomShapeFacets[node.Value] = n
 		}
 	}
 	return nil

--- a/example.go
+++ b/example.go
@@ -2,78 +2,29 @@ package raml
 
 import (
 	"fmt"
-	"os"
-	"path/filepath"
 
 	"gopkg.in/yaml.v3"
 )
 
-// Example represents an example of a shape
-type Example struct {
-	Id              string
-	Name            string
-	Value           any
-	StructuredValue Node
-	MIME            string
-	Location        string
-
-	// To support !include
-	Link *Example
-	Position
-}
-
-// UnmarshalYAML implements the yaml.Unmarshaler interface.
-func (e *Example) UnmarshalYAML(value *yaml.Node) error {
-	if value.Tag == "!include" {
-		baseDir := filepath.Dir(e.Location)
-		example, err := ReadExample(filepath.Join(baseDir, value.Value))
-		if err != nil {
-			return fmt.Errorf("read example: %w", err)
-		}
-		e.Link = example
-		return nil
-	}
-	e.MIME = DetectContentType(value.Value)
-	e.Value = value.Value
-	return nil
-}
-
-// DetectContentType detects the content type of the given value.
-// TODO: Detect content type based on the file header
-func DetectContentType(value string) string {
-	return "text/plain"
-}
-
-// DetectFileMimeType detects the MIME type of the file at the given path.
-func DetectFileMimeType(path string) string {
-	switch filepath.Ext(path) {
-	default:
-		return "text/plain"
-	case ".json":
-		return "application/json"
-	case ".yaml":
-		return "application/yaml"
-	case ".xml":
-		return "application/xml"
-	case ".html":
-		return "text/html"
-	case ".md":
-		return "text/markdown"
-	case ".raml":
-		return "application/x-raml"
-	}
-}
-
-// ReadExample reads an example from the file at the given path.
-// TODO: Move to parse.go?
-func ReadExample(path string) (*Example, error) {
-	bytes, err := os.ReadFile(path)
+func MakeExample(value *yaml.Node, name string, location string) (*Example, error) {
+	n, err := MakeNode(value, location)
 	if err != nil {
-		return nil, fmt.Errorf("read file: %w", err)
+		return nil, fmt.Errorf("make node: %w", err)
 	}
 	return &Example{
-		Value:    string(bytes),
-		Location: path,
-		MIME:     DetectFileMimeType(path),
+		Name:     name,
+		Value:    n,
+		Location: location,
+		Position: Position{Line: value.Line, Column: value.Column},
 	}, nil
+}
+
+// Example represents an example of a shape
+type Example struct {
+	Id       string
+	Name     string
+	Value    *Node
+	Location string
+
+	Position
 }

--- a/extension.go
+++ b/extension.go
@@ -26,13 +26,13 @@ func UnmarshalCustomDomainExtension(location string, keyNode *yaml.Node, valueNo
 	if name == "" {
 		return "", nil, fmt.Errorf("annotation name must not be empty")
 	}
-	dt, err := MakeNode(valueNode, location)
+	n, err := MakeNode(valueNode, location)
 	if err != nil {
 		return "", nil, fmt.Errorf("make node: %w", err)
 	}
 	de := &DomainExtension{
 		Name:      name,
-		Extension: dt,
+		Extension: n,
 		Location:  location,
 		Position:  Position{keyNode.Line, keyNode.Column},
 	}

--- a/parse.go
+++ b/parse.go
@@ -40,9 +40,30 @@ func NewFragmentDecoder(f *os.File, kind FragmentKind) (*yaml.Decoder, error) {
 	return yaml.NewDecoder(r), nil
 }
 
-func ParseDataType(path string) (*DataType, error) {
+func ReadRawFile(path string) (io.ReadCloser, error) {
 	// Library paths must be normalized to simplify dependent libraries resolution.
 	// Convert rel to abs relative to current workdir if necessary.
+	// TODO: Add support for URI
+	if !filepath.IsAbs(path) {
+		workdir, err := os.Getwd()
+		if err != nil {
+			return nil, fmt.Errorf("get workdir: %w", err)
+		}
+		path = filepath.Join(workdir, path)
+	}
+
+	f, err := os.OpenFile(path, os.O_RDONLY, os.ModePerm)
+	if err != nil {
+		log.Fatalf("open file error: %v", err)
+		return nil, fmt.Errorf("open file: %w", err)
+	}
+
+	return f, nil
+}
+
+func ParseDataType(path string) (*DataType, error) {
+	// NOTE: May generate recursive structure.
+	// Fragment paths must be normalized to absolute paths to simplify dependent libraries resolution.
 	// TODO: Add support for URI
 	if !filepath.IsAbs(path) {
 		workdir, err := os.Getwd()
@@ -75,9 +96,9 @@ func ParseDataType(path string) (*DataType, error) {
 		if err != nil {
 			return nil, fmt.Errorf("read file: %w", err)
 		}
-		dt := MakeDataType(path)
-		if err := dt.UnmarshalJSON(data); err != nil {
-			return nil, fmt.Errorf("unmarshal json: %w", err)
+		dt, err := MakeJsonDataType(data, path)
+		if err != nil {
+			return nil, fmt.Errorf("make json data type: %w", err)
 		}
 		GetRegistry().PutFragment(path, dt)
 		return dt, nil
@@ -94,12 +115,23 @@ func ParseDataType(path string) (*DataType, error) {
 	}
 	GetRegistry().PutFragment(path, dt)
 
+	baseDir := filepath.Dir(dt.Location)
+	for _, include := range dt.Uses {
+		// IMPORTANT: Library recursion will NEVER happen inside data types on the parser level since data type is a leaf fragment.
+		// However, consumers (resolvers, external clients) must implement recursion detection when traversing links.
+		sublib, err := ParseLibrary(filepath.Join(baseDir, include.Value), make([]string, 0))
+		if err != nil {
+			return nil, fmt.Errorf("parse library: %w", err)
+		}
+		include.Link = sublib
+	}
+
 	return dt, nil
 }
 
-func ParseLibrary(path string) (*Library, error) {
-	// Library paths must be normalized to simplify dependent libraries resolution.
-	// Convert rel to abs relative to current workdir if necessary.
+func ParseLibrary(path string, history []string) (*Library, error) {
+	// NOTE: May generate recursive structure.
+	// Fragment paths must be normalized to absolute paths to simplify dependent libraries resolution.
 	// TODO: Add support for URI
 	if !filepath.IsAbs(path) {
 		workdir, err := os.Getwd()
@@ -108,6 +140,18 @@ func ParseLibrary(path string) (*Library, error) {
 		}
 		path = filepath.Join(workdir, path)
 	}
+
+	// NOTE: Library recursion may happen on the parser level in cases when a library includes itself directly or indirectly.
+	for i, item := range history {
+		if item == path {
+			p := strings.Join(history[i:], " -> ")
+			return nil, fmt.Errorf("circular reference detected: %s -> %s", p, path)
+		}
+	}
+	// We need to create a new history slice to avoid modifying the original one in subsequent calls.
+	newHistory := make([]string, len(history)+1)
+	copy(newHistory, history)
+	newHistory[len(history)] = path
 
 	if lib := GetRegistry().GetFragment(path); lib != nil {
 		// log.Printf("reusing fragment %s", path)
@@ -137,5 +181,58 @@ func ParseLibrary(path string) (*Library, error) {
 	}
 	GetRegistry().PutFragment(path, lib)
 
+	// Resolve included libraries in a separate stage.
+	baseDir := filepath.Dir(lib.Location)
+	for _, include := range lib.Uses {
+		sublib, err := ParseLibrary(filepath.Join(baseDir, include.Value), newHistory)
+		if err != nil {
+			return nil, fmt.Errorf("parse library: %w", err)
+		}
+		include.Link = sublib
+	}
+
 	return lib, nil
+}
+
+func ParseNamedExample(path string) (*NamedExample, error) {
+	// Library paths must be normalized to simplify dependent libraries resolution.
+	// Convert rel to abs relative to current workdir if necessary.
+	// TODO: Add support for URI
+	if !filepath.IsAbs(path) {
+		workdir, err := os.Getwd()
+		if err != nil {
+			return nil, fmt.Errorf("get workdir: %w", err)
+		}
+		path = filepath.Join(workdir, path)
+	}
+
+	if lib := GetRegistry().GetFragment(path); lib != nil {
+		// log.Printf("reusing fragment %s", path)
+		return lib.(*NamedExample), nil
+	}
+
+	f, err := os.OpenFile(path, os.O_RDONLY, os.ModePerm)
+	if err != nil {
+		log.Fatalf("open file error: %v", err)
+		return nil, fmt.Errorf("open file: %w", err)
+	}
+	defer func(f *os.File) {
+		err = f.Close()
+		if err != nil {
+			log.Fatal(fmt.Errorf("close file error: %w", err))
+		}
+	}(f)
+
+	decoder, err := NewFragmentDecoder(f, FragmentNamedExample)
+	if err != nil {
+		return nil, fmt.Errorf("new fragment decoder: %w", err)
+	}
+
+	ne := MakeNamedExample(path)
+	if err := decoder.Decode(&ne); err != nil {
+		return nil, fmt.Errorf("decode fragment: %w", err)
+	}
+	GetRegistry().PutFragment(path, ne)
+
+	return ne, nil
 }

--- a/rdt_visitor.go
+++ b/rdt_visitor.go
@@ -157,7 +157,7 @@ func (visitor *RdtVisitor) VisitReference(ctx *rdt.ReferenceContext, target *Unk
 		if lib == nil {
 			return nil, fmt.Errorf("library %s not found", parts[0])
 		}
-		ref = lib.Types[parts[1]]
+		ref = lib.Link.Types[parts[1]]
 		if ref == nil {
 			return nil, fmt.Errorf("reference %s not found", parts[1])
 		}

--- a/registry.go
+++ b/registry.go
@@ -11,6 +11,7 @@ type Registry struct {
 
 	// May be reused for both validation and resolution.
 	DomainExtensions []*DomainExtension
+
 	// TODO: Temporary shape buffers for resolution and counting.
 	UnresolvedShapes []*Shape
 	ResolvedShapes   []*Shape

--- a/resolve.go
+++ b/resolve.go
@@ -47,7 +47,7 @@ func ResolveDomainExtension(de *DomainExtension) error {
 			if lib == nil {
 				return fmt.Errorf("library %s not found", parts[0])
 			}
-			ref = lib.AnnotationTypes[parts[1]]
+			ref = lib.Link.AnnotationTypes[parts[1]]
 			if ref == nil {
 				return fmt.Errorf("reference %s not found", parts[1])
 			}
@@ -61,7 +61,7 @@ func ResolveDomainExtension(de *DomainExtension) error {
 			if lib == nil {
 				return fmt.Errorf("library %s not found", parts[0])
 			}
-			ref = lib.AnnotationTypes[parts[1]]
+			ref = lib.Link.AnnotationTypes[parts[1]]
 			if ref == nil {
 				return fmt.Errorf("reference %s not found", parts[1])
 			}

--- a/scalars.go
+++ b/scalars.go
@@ -7,7 +7,22 @@ import (
 )
 
 type EnumFacets struct {
-	Enum []Node
+	Enum []*Node
+}
+
+func MakeEnum(v *yaml.Node, location string) ([]*Node, error) {
+	if v.Kind != yaml.SequenceNode {
+		return nil, fmt.Errorf("enum must be sequence node")
+	}
+	var enums []*Node = make([]*Node, len(v.Content))
+	for i, v := range v.Content {
+		n, err := MakeNode(v, location)
+		if err != nil {
+			return nil, fmt.Errorf("make node enum: %w", err)
+		}
+		enums[i] = n
+	}
+	return enums, nil
 }
 
 type FormatFacets struct {
@@ -69,15 +84,17 @@ func (s *IntegerShape) UnmarshalYAMLNodes(v []*yaml.Node) error {
 				return fmt.Errorf("decode format: %w", err)
 			}
 		} else if node.Value == "enum" {
-			if err := valueNode.Decode(&s.Enum); err != nil {
-				return fmt.Errorf("decode enum: %w", err)
+			enums, err := MakeEnum(valueNode, s.Location)
+			if err != nil {
+				return fmt.Errorf("make enum: %w", err)
 			}
+			s.Enum = enums
 		} else {
-			dt, err := MakeNode(valueNode, s.Location)
+			n, err := MakeNode(valueNode, s.Location)
 			if err != nil {
 				return fmt.Errorf("make node: %w", err)
 			}
-			s.CustomShapeFacets[node.Value] = dt
+			s.CustomShapeFacets[node.Value] = n
 		}
 	}
 	return nil
@@ -122,19 +139,21 @@ func (s *NumberShape) UnmarshalYAMLNodes(v []*yaml.Node) error {
 				return fmt.Errorf("decode format: %w", err)
 			}
 		} else if node.Value == "enum" {
-			if err := valueNode.Decode(&s.Enum); err != nil {
-				return fmt.Errorf("decode enum: %w", err)
+			enums, err := MakeEnum(valueNode, s.Location)
+			if err != nil {
+				return fmt.Errorf("make enum: %w", err)
 			}
+			s.Enum = enums
 		} else if node.Value == "multipleOf" {
 			if err := valueNode.Decode(&s.MultipleOf); err != nil {
 				return fmt.Errorf("decode multipleOf: %w", err)
 			}
 		} else {
-			dt, err := MakeNode(valueNode, s.Location)
+			n, err := MakeNode(valueNode, s.Location)
 			if err != nil {
 				return fmt.Errorf("make node: %w", err)
 			}
-			s.CustomShapeFacets[node.Value] = dt
+			s.CustomShapeFacets[node.Value] = n
 		}
 	}
 	return nil
@@ -184,15 +203,17 @@ func (s *StringShape) UnmarshalYAMLNodes(v []*yaml.Node) error {
 				return fmt.Errorf("decode pattern: %w", err)
 			}
 		} else if node.Value == "enum" {
-			if err := valueNode.Decode(&s.Enum); err != nil {
-				return fmt.Errorf("decode enum: %w", err)
+			enums, err := MakeEnum(valueNode, s.Location)
+			if err != nil {
+				return fmt.Errorf("make enum: %w", err)
 			}
+			s.Enum = enums
 		} else {
-			dt, err := MakeNode(valueNode, s.Location)
+			n, err := MakeNode(valueNode, s.Location)
 			if err != nil {
 				return fmt.Errorf("make node: %w", err)
 			}
-			s.CustomShapeFacets[node.Value] = dt
+			s.CustomShapeFacets[node.Value] = n
 		}
 	}
 	return nil
@@ -236,11 +257,11 @@ func (s *FileShape) UnmarshalYAMLNodes(v []*yaml.Node) error {
 				return fmt.Errorf("decode fileTypes: %w", err)
 			}
 		} else {
-			dt, err := MakeNode(valueNode, s.Location)
+			n, err := MakeNode(valueNode, s.Location)
 			if err != nil {
 				return fmt.Errorf("make node: %w", err)
 			}
-			s.CustomShapeFacets[node.Value] = dt
+			s.CustomShapeFacets[node.Value] = n
 		}
 	}
 	return nil
@@ -267,15 +288,17 @@ func (s *BooleanShape) UnmarshalYAMLNodes(v []*yaml.Node) error {
 		valueNode := v[i+1]
 
 		if node.Value == "enum" {
-			if err := valueNode.Decode(&s.Enum); err != nil {
-				return fmt.Errorf("decode enum: %w", err)
+			enums, err := MakeEnum(valueNode, s.Location)
+			if err != nil {
+				return fmt.Errorf("make enum: %w", err)
 			}
+			s.Enum = enums
 		} else {
-			dt, err := MakeNode(valueNode, s.Location)
+			n, err := MakeNode(valueNode, s.Location)
 			if err != nil {
 				return fmt.Errorf("make node: %w", err)
 			}
-			s.CustomShapeFacets[node.Value] = dt
+			s.CustomShapeFacets[node.Value] = n
 		}
 	}
 
@@ -306,11 +329,11 @@ func (s *DateTimeShape) UnmarshalYAMLNodes(v []*yaml.Node) error {
 				return fmt.Errorf("decode format: %w", err)
 			}
 		} else {
-			dt, err := MakeNode(valueNode, s.Location)
+			n, err := MakeNode(valueNode, s.Location)
 			if err != nil {
 				return fmt.Errorf("make node: %w", err)
 			}
-			s.CustomShapeFacets[node.Value] = dt
+			s.CustomShapeFacets[node.Value] = n
 		}
 	}
 	return nil


### PR DESCRIPTION
* Split BaseShape `[]*Example` into `*Example` and `*Examples`.
* Reduce DataNode value to `interface{}`.
* Support includes in DataNode.
* Support YAML and JSON decoding in DataNode for JSON and YAML files.
* Handle recursive includes on parser level.
* Implement library recursion detection.
* Refactor library resolution into a separate stage.
* Add container sizes where possible.
* Support NamedExample fragment.