### PR TITLE
Improvements and fixes

### DIFF
--- a/example.go
+++ b/example.go
@@ -15,7 +15,7 @@ func (r *RAML) makeExample(value *yaml.Node, name string, location string) (*Exa
 	}
 	return &Example{
 		Name:     name,
-		Value:    n,
+		Data:     n,
 		Location: location,
 		Position: Position{Line: value.Line, Column: value.Column},
 		raml:     r,
@@ -28,7 +28,7 @@ type Example struct {
 	Name        string
 	DisplayName string
 	Description string
-	Value       *Node
+	Data        *Node
 
 	CustomDomainProperties CustomDomainProperties
 

--- a/fragment.go
+++ b/fragment.go
@@ -101,7 +101,7 @@ func (l *Library) UnmarshalYAML(value *yaml.Node) error {
 					return NewWrappedError("parse types: make shape", err, l.Location, WithNodePosition(data))
 				}
 				l.Types[name] = shape
-				l.raml.PutIntoFragment(name, l.Location, shape)
+				l.raml.PutTypeIntoFragment(name, l.Location, shape)
 				l.raml.PutShapePtr(shape)
 			}
 		} else if node.Value == "annotationTypes" {
@@ -119,6 +119,7 @@ func (l *Library) UnmarshalYAML(value *yaml.Node) error {
 					return NewWrappedError("parse annotation types: make shape", err, l.Location, WithNodePosition(data))
 				}
 				l.AnnotationTypes[name] = shape
+				l.raml.PutAnnotationTypeIntoFragment(name, l.Location, shape)
 				l.raml.PutShapePtr(shape)
 			}
 		} else if node.Value == "usage" {
@@ -227,8 +228,8 @@ func (r *RAML) MakeJsonDataType(value []byte, path string) (*DataType, error) {
 
 // NamedExample is the RAML 1.0 NamedExample
 type NamedExample struct {
-	Id       string
-	Examples map[string]*Example
+	Id  string
+	Map map[string]*Example
 
 	Location string
 	raml     *RAML
@@ -259,7 +260,7 @@ func (ne *NamedExample) UnmarshalYAML(value *yaml.Node) error {
 		}
 		examples[node.Value] = example
 	}
-	ne.Examples = examples
+	ne.Map = examples
 
 	return nil
 }

--- a/rdt_visitor.go
+++ b/rdt_visitor.go
@@ -165,6 +165,9 @@ func (visitor *RdtVisitor) VisitReference(ctx *rdt.ReferenceContext, target *Unk
 	} else {
 		return nil, fmt.Errorf("invalid reference %s", shapeType)
 	}
+	if (*ref).Base().Id == target.Id {
+		return nil, fmt.Errorf("self recursion %s", shapeType)
+	}
 	if err := visitor.raml.resolveShape(ref); err != nil {
 		return nil, fmt.Errorf("resolve: %w", err)
 	}

--- a/resolve.go
+++ b/resolve.go
@@ -9,13 +9,20 @@ import (
 	"github.com/acronis/go-raml/rdt"
 )
 
+/*
+Resolve resolves all unresolved (UnknownShape) shapes in the RAML.
+
+NOTE: Unresolved shapes is a linked list that is populated by the YAML parser. Shape parsing occurs in two places:
+
+1. During the RAML fragment parsing. Shapes that could not be determined during the parsing process
+are stored in `unresolvedShapes` as UnknownShape. UnknownShape includes YAML nodes that can be parsed later.
+
+2. During the shape resolution. YAML parser is invoked on YAML nodes that UnknownShape has stored.
+
+This helps to avoid additional traversals of nested shapes since the traverse is already done by YAML parser and it will
+generate UnknownShapes and add them to `unresolvedShapes` recursively as they occur.
+*/
 func (r *RAML) resolveShapes() error {
-	// NOTE: Unresolved shapes is a linked list that is populated by the YAML parser. Shape parsing occurs in two places:
-	// 1. During the RAML fragment parsing. Shapes that could not be determined during the parsing process
-	// are stored in `unresolvedShapes` as UnknownShape. UnknownShape includes YAML nodes that can be parsed later.
-	// 2. During the shape resolution. YAML parser is invoked on YAML nodes that UnknownShape has stored.
-	// This helps to avoid additional traversals of nested shapes since the traverse is already done by YAML parser and it will
-	// generate UnknownShapes and add them to `unresolvedShapes` recursively as they occur.
 	for r.unresolvedShapes.Len() > 0 {
 		v := r.unresolvedShapes.Front()
 		if err := r.resolveShape(v.Value.(*Shape)); err != nil {

--- a/schema.go
+++ b/schema.go
@@ -1,0 +1,114 @@
+package raml
+
+import "encoding/json"
+
+// Version is the JSON Schema version.
+var Version = "http://json-schema.org/draft-07/schema"
+
+// Schema represents a JSON Schema object type.
+//
+// https://json-schema.org/draft-07/draft-handrews-json-schema-00.pdf
+type JSONSchema struct {
+	Version     string      `json:"$schema,omitempty"`
+	ID          string      `json:"$id,omitempty"`
+	Anchor      string      `json:"$anchor,omitempty"`
+	Ref         string      `json:"$ref,omitempty"`
+	Definitions Definitions `json:"definitions,omitempty"`
+	Comment     string      `json:"$comment,omitempty"`
+
+	AllOf []*JSONSchema `json:"allOf,omitempty"`
+	AnyOf []*JSONSchema `json:"anyOf,omitempty"`
+	OneOf []*JSONSchema `json:"oneOf,omitempty"`
+	Not   *JSONSchema   `json:"not,omitempty"`
+
+	If   *JSONSchema `json:"if,omitempty"`
+	Then *JSONSchema `json:"then,omitempty"`
+	Else *JSONSchema `json:"else,omitempty"`
+
+	Items *JSONSchema `json:"items,omitempty"`
+
+	Properties           map[string]*JSONSchema `json:"properties,omitempty"`
+	PatternProperties    map[string]*JSONSchema `json:"patternProperties,omitempty"`
+	AdditionalProperties *bool                  `json:"additionalProperties,omitempty"`
+	PropertyNames        *JSONSchema            `json:"propertyNames,omitempty"`
+
+	Type             string      `json:"type,omitempty"`
+	Enum             []any       `json:"enum,omitempty"`
+	Const            any         `json:"const,omitempty"`
+	MultipleOf       json.Number `json:"multipleOf,omitempty"`
+	Maximum          json.Number `json:"maximum,omitempty"`
+	Minimum          json.Number `json:"minimum,omitempty"`
+	MaxLength        *uint64     `json:"maxLength,omitempty"`
+	MinLength        *uint64     `json:"minLength,omitempty"`
+	Pattern          string      `json:"pattern,omitempty"`
+	MaxItems         *uint64     `json:"maxItems,omitempty"`
+	MinItems         *uint64     `json:"minItems,omitempty"`
+	UniqueItems      bool        `json:"uniqueItems,omitempty"`
+	MaxContains      *uint64     `json:"maxContains,omitempty"`
+	MinContains      *uint64     `json:"minContains,omitempty"`
+	MaxProperties    *uint64     `json:"maxProperties,omitempty"`
+	MinProperties    *uint64     `json:"minProperties,omitempty"`
+	Required         []string    `json:"required,omitempty"`
+	ContentEncoding  string      `json:"contentEncoding,omitempty"`
+	ContentMediaType string      `json:"contentMediaType,omitempty"`
+
+	Format string `json:"format,omitempty"`
+
+	Title       string `json:"title,omitempty"`
+	Description string `json:"description,omitempty"`
+	Default     any    `json:"default,omitempty"`
+	Examples    []any  `json:"examples,omitempty"`
+
+	// TODO: There's no better way to serialize custom properties on the same level in Go.
+	Extras map[string]any `json:"x-custom,omitempty"`
+
+	// Special boolean representation of the Schema
+	boolean *bool
+}
+
+var (
+	// TrueSchema defines a schema with a true value
+	TrueSchema = &JSONSchema{boolean: &[]bool{true}[0]}
+	// FalseSchema defines a schema with a false value
+	FalseSchema = &JSONSchema{boolean: &[]bool{false}[0]}
+)
+
+// Definitions hold schema definitions.
+// http://json-schema.org/latest/json-schema-validation.html#rfc.section.5.26
+// RFC draft-wright-json-schema-validation-00, section 5.26
+type Definitions map[string]*JSONSchema
+
+func (schema *JSONSchema) WithRamlData(base *BaseShape) {
+	if base.DisplayName != nil {
+		schema.Title = *base.DisplayName
+	}
+	if base.Description != nil {
+		schema.Description = *base.Description
+	}
+	if base.Default != nil {
+		schema.Default = base.Default.Value
+	}
+	if base.Examples != nil {
+		for _, ex := range base.Examples.Map {
+			schema.Examples = append(schema.Examples, ex.Data.Value)
+		}
+	}
+	if base.Example != nil {
+		schema.Examples = []any{base.Example.Data.Value}
+	}
+	for k, v := range base.CustomDomainProperties {
+		schema.Extras["x-domainExt-"+k] = v.Extension.Value
+	}
+	for k, v := range base.CustomShapeFacetDefinitions {
+		m := schema.Extras["x-shapeExt-definitions"]
+		if m == nil {
+			m = make(map[string]interface{})
+			schema.Extras["x-shapeExt-definitions"] = m
+		}
+		shapeExtDefs := m.(map[string]interface{})
+		shapeExtDefs[k] = (*v.Shape).ToJSONSchema()
+	}
+	for k, v := range base.CustomShapeFacets {
+		schema.Extras["x-shapeExt-data-"+k] = v.Value
+	}
+}

--- a/schema.go
+++ b/schema.go
@@ -2,6 +2,8 @@ package raml
 
 import "encoding/json"
 
+// Adapted from https://github.com/invopop/jsonschema/blob/main/schema.go
+
 // Version is the JSON Schema version.
 var Version = "http://json-schema.org/draft-07/schema"
 

--- a/unwrap.go
+++ b/unwrap.go
@@ -1,14 +1,15 @@
 package raml
 
-import "fmt"
+/*
+UnwrapShapes unwraps all shapes in the RAML.
 
-// UnwrapShapes unwraps all shapes in the RAML.
+NOTE: With unwrap, we replace pointers to definitions instead of values by pointers to keep original parents unchanged.
+Otherwise, parents will be also modified and unwrap may produce unpredictable results.
+
+Unfortunately, this is required to properly support recursive shapes.
+A more sophisticated approach is required to save memory and avoid copies.
+*/
 func (r *RAML) UnwrapShapes() error {
-	// NOTE: With unwrap, we replace pointers to definitions instead of values by pointers to keep original parents unchanged.
-	// Otherwise, parents will be also modified and unwrap may produce unpredictable results.
-	// Unfortunately, this is required to properly support recursive shapes.
-	// A more sophisticated approach is required to save memory and avoid copies.
-
 	// We need to invalidate old cache and re-populate it because references will no longer be valid after unwrapping.
 	r.fragmentTypes = make(map[string]map[string]*Shape)
 	r.fragmentAnnotationTypes = make(map[string]map[string]*Shape)


### PR DESCRIPTION
* Rework public clone interface and support recursive shape clone.
* Remove shape ID generation during clone.
* Rework unwrap to fully support recursive types.
* Fix DateTimeOnlyShape type check.
* Add JSONSchema Draft 7.
* Implement conversion to JSON Schema for unwrapped shapes.
* Fix hang on self-recursive type during resolution.
* Fix null pointer dereference when parent ArrayShape and ObjectShape do not define nested shapes.
* Fix pattern properties requirement.
* Refactor Example and Examples struct value names.
* Separate annotationTypes and types per-fragment cache.